### PR TITLE
[2기-C] 유재희 jap misson 3 연관관계 매핑 실습

### DIFF
--- a/lec_JPA/build.gradle
+++ b/lec_JPA/build.gradle
@@ -31,6 +31,8 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.24'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.2'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.6.7'
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.6.1'
+
 
 }
 

--- a/lec_JPA/src/main/java/com/prgrms/lec_jpa/domain/BaseEntity.java
+++ b/lec_JPA/src/main/java/com/prgrms/lec_jpa/domain/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.prgrms.lec_jpa.domain;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BaseEntity {
+
+    @Column(name = "created_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @Column(name = "created_by")
+    private String createdBy;
+
+    protected BaseEntity(LocalDateTime createdAt, String createdBy) {
+
+        this.createdAt = createdAt;
+        this.createdBy = createdBy;
+    }
+}

--- a/lec_JPA/src/main/java/com/prgrms/lec_jpa/domain/Item.java
+++ b/lec_JPA/src/main/java/com/prgrms/lec_jpa/domain/Item.java
@@ -1,0 +1,80 @@
+package com.prgrms.lec_jpa.domain;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "item")
+public class Item extends BaseEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    private long price;
+    private long stockQuantity;
+
+    private Item(ItemBuilder builder) {
+
+        super(LocalDateTime.now(), builder.createdBy);
+        this.price = builder.price;
+        this.stockQuantity = builder.stockQuantity;
+    }
+
+    public Long getId() {
+
+        return id;
+    }
+
+    public long getPrice() {
+
+        return price;
+    }
+
+    public long getStockQuantity() {
+
+        return stockQuantity;
+    }
+
+    public static class ItemBuilder {
+
+        private long price;
+        private long stockQuantity;
+        private String createdBy;
+
+        public ItemBuilder price(long value) {
+
+            this.price = value;
+
+            return this;
+        }
+
+        public ItemBuilder stockQuantity(long value) {
+
+            this.stockQuantity = value;
+
+            return this;
+        }
+
+        public ItemBuilder createdBy(String value) {
+
+            this.createdBy = value;
+
+            return this;
+        }
+
+        public Item build() {
+
+            return new Item(this);
+        }
+    }
+
+    public static ItemBuilder builder() {
+
+        return new ItemBuilder();
+    }
+}

--- a/lec_JPA/src/main/java/com/prgrms/lec_jpa/domain/Member.java
+++ b/lec_JPA/src/main/java/com/prgrms/lec_jpa/domain/Member.java
@@ -1,0 +1,134 @@
+package com.prgrms.lec_jpa.domain;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "member")
+public class Member extends BaseEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 30)
+    private String name;
+
+    @Column(name = "nick_name", nullable = false, length = 30, unique = true)
+    private String nickName;
+
+    @Column(name = "age", nullable = false)
+    private int age;
+
+    @Column(name = "address", nullable = false)
+    private String address;
+
+    @Column(name = "description")
+    private String description;
+
+    private Member(MemberBuilder builder) {
+
+        super(LocalDateTime.now(), builder.createdBy);
+        this.name = builder.name;
+        this.nickName = builder.nickName;
+        this.age = builder.age;
+        this.address = builder.address;
+        this.description = builder.description;
+    }
+
+    public Long getId() {
+
+        return id;
+    }
+
+    public String getName() {
+
+        return name;
+    }
+
+    public String getNickName() {
+
+        return nickName;
+    }
+
+    public int getAge() {
+
+        return age;
+    }
+
+    public String getAddress() {
+
+        return address;
+    }
+
+    public String getDescription() {
+
+        return description;
+    }
+
+    public static class MemberBuilder {
+
+        private String name;
+        private String nickName;
+        private int age;
+        private String address;
+        private String description;
+        private String createdBy;
+
+        public MemberBuilder name(String value) {
+
+            this.name = value;
+
+            return this;
+        }
+
+        public MemberBuilder nickName(String value) {
+
+            this.nickName = value;
+
+            return this;
+        }
+
+        public MemberBuilder age(int value) {
+
+            this.age = value;
+
+            return this;
+        }
+
+        public MemberBuilder address(String value) {
+
+            this.address = value;
+
+            return this;
+        }
+
+        public MemberBuilder description(String value) {
+
+            this.description = value;
+
+            return this;
+        }
+
+        public MemberBuilder createdBy(String value) {
+
+            this.createdBy = value;
+
+            return this;
+        }
+
+        public Member build() {
+
+            return new Member(this);
+        }
+    }
+
+    public static MemberBuilder builder() {
+
+        return new MemberBuilder();
+    }
+}

--- a/lec_JPA/src/main/java/com/prgrms/lec_jpa/domain/Order.java
+++ b/lec_JPA/src/main/java/com/prgrms/lec_jpa/domain/Order.java
@@ -1,0 +1,101 @@
+package com.prgrms.lec_jpa.domain;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "orders")
+public class Order extends BaseEntity{
+
+    @Id
+    @Column(name = "id")
+    private String uuid;
+
+    @Lob
+    private String memo;
+
+    @Enumerated(value = EnumType.STRING)
+    private OrderStatus orderStatus;
+
+    @Column(name = "created_order_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdOrderAt;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", referencedColumnName = "id")
+    private Member member;
+
+    private Order(OrderBuilder builder) {
+
+        super(LocalDateTime.now(), builder.createdBy);
+        this.uuid = UUID.randomUUID().toString();
+        this.memo = builder.memo;
+        this.orderStatus = OrderStatus.OPENED;
+        this.createdOrderAt = LocalDateTime.now();
+    }
+
+    public void setMember(Member member) {
+
+        this.member = member;
+    }
+
+    public String getUuid() {
+
+        return uuid;
+    }
+
+    public String getMemo() {
+
+        return memo;
+    }
+
+    public OrderStatus getOrderStatus() {
+
+        return orderStatus;
+    }
+
+    public LocalDateTime getCreatedOrderAt() {
+
+        return createdOrderAt;
+    }
+
+    public Member getMember() {
+
+        return member;
+    }
+
+    public static class OrderBuilder {
+
+        private String memo;
+
+        private String createdBy;
+
+        public OrderBuilder memo(String value) {
+
+            this.memo = value;
+
+            return this;
+        }
+
+        public OrderBuilder createdBy(String value) {
+
+            this.createdBy = value;
+
+            return this;
+        }
+
+        public Order build() {
+
+            return new Order(this);
+        }
+    }
+
+    public static OrderBuilder builder() {
+
+        return new OrderBuilder();
+    }
+}

--- a/lec_JPA/src/main/java/com/prgrms/lec_jpa/domain/OrderItem.java
+++ b/lec_JPA/src/main/java/com/prgrms/lec_jpa/domain/OrderItem.java
@@ -1,0 +1,107 @@
+package com.prgrms.lec_jpa.domain;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "order_item")
+public class OrderItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    private long price;
+    private long quantity;
+
+    @ManyToOne
+    @JoinColumn(name = "order_id", referencedColumnName = "id")
+    private Order order;
+
+    @ManyToOne
+    @JoinColumn(name = "item_id", referencedColumnName = "id")
+    private Item item;
+
+    private OrderItem(OrderItemBuilder builder) {
+
+        super(LocalDateTime.now(), builder.createdBy);
+        this.price = builder.price;
+        this.quantity = builder.quantity;
+    }
+
+    public void setOrder(Order order) {
+
+        this.order = order;
+    }
+
+    public void setItem(Item item) {
+
+        this.item = item;
+    }
+
+    public Long getId() {
+
+        return id;
+    }
+
+    public long getPrice() {
+
+        return price;
+    }
+
+    public long getQuantity() {
+
+        return quantity;
+    }
+
+    public Order getOrder() {
+
+        return order;
+    }
+
+    public Item getItem() {
+        return item;
+    }
+
+    public static class OrderItemBuilder {
+
+        private long price;
+        private long quantity;
+        private String createdBy;
+
+        public OrderItemBuilder price(long value) {
+
+            this.price = value;
+
+            return this;
+        }
+
+        public OrderItemBuilder quantity(long value) {
+
+            this.quantity = value;
+
+            return this;
+        }
+
+        public OrderItemBuilder createdBy(String value) {
+
+            this.createdBy = value;
+
+            return this;
+        }
+
+        public OrderItem build() {
+
+            return new OrderItem(this);
+        }
+    }
+
+    public static OrderItemBuilder builder() {
+
+        return new OrderItemBuilder();
+    }
+}

--- a/lec_JPA/src/main/java/com/prgrms/lec_jpa/domain/OrderStatus.java
+++ b/lec_JPA/src/main/java/com/prgrms/lec_jpa/domain/OrderStatus.java
@@ -1,0 +1,5 @@
+package com.prgrms.lec_jpa.domain;
+
+public enum OrderStatus {
+    OPENED, CANCELED
+}

--- a/lec_JPA/src/main/java/com/prgrms/lec_jpa/domain/OrderStatus.java
+++ b/lec_JPA/src/main/java/com/prgrms/lec_jpa/domain/OrderStatus.java
@@ -1,5 +1,6 @@
 package com.prgrms.lec_jpa.domain;
 
 public enum OrderStatus {
+
     OPENED, CANCELED
 }

--- a/lec_JPA/src/test/java/com/prgrms/lec_jpa/domain/OrderPersistentTest.java
+++ b/lec_JPA/src/test/java/com/prgrms/lec_jpa/domain/OrderPersistentTest.java
@@ -1,0 +1,102 @@
+package com.prgrms.lec_jpa.domain;
+
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityTransaction;
+
+@SpringBootTest
+@Slf4j
+public class OrderPersistentTest {
+
+    @Autowired
+    EntityManagerFactory emf;
+
+    @Test
+    void save_test() {
+
+        Member member = Member.builder()
+                .name("jahee")
+                .address("home")
+                .age(28)
+                .description("whiteHands")
+                .nickName("jj")
+                .createdBy("jaehee")
+                .build();
+
+        EntityManager em = emf.createEntityManager();
+        EntityTransaction transaction = em.getTransaction();
+        transaction.begin();
+
+        em.persist(member);
+        transaction.commit();
+    }
+
+    @Test
+    void associate_test() {
+
+        //given
+        EntityManager em = emf.createEntityManager();
+        EntityTransaction transaction = em.getTransaction();
+
+        transaction.begin();
+
+        Member member = Member.builder()
+                .name("jaehee")
+                .address("home")
+                .age(28)
+                .description("whiteHands")
+                .nickName("jj")
+                .createdBy("jaehee")
+                .build();
+
+        em.persist(member);
+
+        Item item = Item.builder()
+                .price(1000)
+                .stockQuantity(100)
+                .createdBy("jaehee")
+                .build();
+
+        em.persist(item);
+
+        Order order = Order.builder()
+                .memo("Car Order")
+                .createdBy("jaehee")
+                .build();
+
+        order.setMember(member);
+
+        em.persist(order);
+
+        OrderItem orderItem = OrderItem.builder()
+                .price(1000)
+                .quantity(3)
+                .createdBy("jaehee")
+                .build();
+
+        orderItem.setItem(item);
+        orderItem.setOrder(order);
+
+        em.persist(orderItem);
+
+        transaction.commit();
+
+        //when
+        OrderItem entity = em.find(OrderItem.class, orderItem.getId());
+
+        String memberNameExpected = entity.getOrder().getMember().getName();
+        long itemPriceExpected = entity.getItem().getPrice();
+        String orderMemoExpected = entity.getOrder().getMemo();
+
+        //then
+        Assertions.assertThat(memberNameExpected).isEqualTo(member.getName());
+        Assertions.assertThat(itemPriceExpected).isEqualTo(item.getPrice());
+        Assertions.assertThat(orderMemoExpected).isEqualTo(order.getMemo());
+    }
+}

--- a/lec_JPA/src/test/java/com/prgrms/lec_jpa/domain/OrderPersistentTest.java
+++ b/lec_JPA/src/test/java/com/prgrms/lec_jpa/domain/OrderPersistentTest.java
@@ -90,9 +90,14 @@ public class OrderPersistentTest {
         //when
         OrderItem entity = em.find(OrderItem.class, orderItem.getId());
 
-        String memberNameExpected = entity.getOrder().getMember().getName();
-        long itemPriceExpected = entity.getItem().getPrice();
-        String orderMemoExpected = entity.getOrder().getMemo();
+        Order associatedOrder = entity.getOrder();
+        Member associatedMember = associatedOrder.getMember();
+
+        Item associatedItem = entity.getItem();
+
+        String memberNameExpected = associatedMember.getName();
+        long itemPriceExpected = associatedItem.getPrice();
+        String orderMemoExpected = associatedOrder.getMemo();
 
         //then
         Assertions.assertThat(memberNameExpected).isEqualTo(member.getName());


### PR DESCRIPTION
<img width="322" alt="image" src="https://user-images.githubusercontent.com/57293011/168280589-eb305ea1-2631-4bd4-ac75-2a2d913b0a97.png">


다대일 관계를 갖는 엔티티만 단방향으로 연관관계를 갖도록 설계했습니다.

양방향으로 연관관계를 갖게되면 순환참조 문제와 필요하지 않은 필드를 갖고 있을 수 있다고 생각해서 단방향으로만 처리하도록 만들었습니다!

빌더패턴을 적용해봤습니다.

감사합니다!