### PR TITLE
[2기 - P] 이연우 Mission 3 : 연관관계매핑

### DIFF
--- a/src/main/java/com/example/springjpa/order/Book.java
+++ b/src/main/java/com/example/springjpa/order/Book.java
@@ -1,0 +1,22 @@
+package com.example.springjpa.order;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@DiscriminatorValue("Book")
+public class Book extends Item{
+	private String title;
+
+	protected Book() {}
+	public Book(int price, int stockQuantity, String title) {
+		super(price, stockQuantity);
+		this.title = title;
+	}
+}

--- a/src/main/java/com/example/springjpa/order/CreationEntity.java
+++ b/src/main/java/com/example/springjpa/order/CreationEntity.java
@@ -1,0 +1,21 @@
+package com.example.springjpa.order;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.MappedSuperclass;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@MappedSuperclass
+public class CreationEntity {
+	@Column(name = "created_at", columnDefinition = "TIMESTAMP")
+	private LocalDateTime createdAt;
+
+	public CreationEntity() {
+		this.createdAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/example/springjpa/order/Furniture.java
+++ b/src/main/java/com/example/springjpa/order/Furniture.java
@@ -1,0 +1,23 @@
+package com.example.springjpa.order;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@DiscriminatorValue("Furniture")
+public class Furniture extends Item{
+	private int width;
+	private int height;
+
+	protected Furniture() {}
+	public Furniture(int price, int stockQuantity, int width, int height) {
+		super(price, stockQuantity);
+		this.width = width;
+		this.height = height;
+	}
+}

--- a/src/main/java/com/example/springjpa/order/Item.java
+++ b/src/main/java/com/example/springjpa/order/Item.java
@@ -1,0 +1,36 @@
+package com.example.springjpa.order;
+
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "item")
+@Getter
+@Setter
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "DTYPE")
+public abstract class Item extends CreationEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE)
+	private Long id;
+
+	private int price;
+	private int stockQuantity;
+
+	protected Item() {
+	}
+
+	public Item(int price, int stockQuantity) {
+		this.price = price;
+		this.stockQuantity = stockQuantity;
+	}
+}

--- a/src/main/java/com/example/springjpa/order/Member.java
+++ b/src/main/java/com/example/springjpa/order/Member.java
@@ -51,8 +51,6 @@ public class Member extends CreationEntity {
 	}
 
 	public void addOrder(Order order) {
-		orders.add(order);
-
 		order.orderedByMember(this);
 	}
 }

--- a/src/main/java/com/example/springjpa/order/Member.java
+++ b/src/main/java/com/example/springjpa/order/Member.java
@@ -1,0 +1,58 @@
+package com.example.springjpa.order;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "member")
+@Getter
+@Setter
+public class Member extends CreationEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE)
+	private Long id;
+
+	@Column(name = "name", nullable = false, length = 30)
+	private String name;
+	@Column(name = "nickName", nullable = false, length = 30, unique = true)
+	private String nickName;
+	@Column(name = "age", nullable = false)
+	private int age;
+	@Column(name = "address", nullable = false)
+	private String address;
+	@Column(name = "description")
+	private String description;
+
+	@OneToMany(mappedBy = "member",
+		cascade = CascadeType.ALL
+	)
+	private List<Order> orders = new ArrayList<>();
+
+	protected Member() {
+	}
+
+	public Member(String name, String nickName, int age, String address) {
+		this.name = name;
+		this.nickName = nickName;
+		this.age = age;
+		this.address = address;
+	}
+
+	public void addOrder(Order order) {
+		orders.add(order);
+
+		order.orderedByMember(this);
+	}
+}

--- a/src/main/java/com/example/springjpa/order/Order.java
+++ b/src/main/java/com/example/springjpa/order/Order.java
@@ -66,8 +66,6 @@ public class Order extends CreationEntity {
 	}
 
 	public void addOrderItem(OrderItem orderItem) {
-		this.orderItems.add(orderItem);
-
 		orderItem.addToOrder(this);
 	}
 }

--- a/src/main/java/com/example/springjpa/order/Order.java
+++ b/src/main/java/com/example/springjpa/order/Order.java
@@ -1,0 +1,73 @@
+package com.example.springjpa.order;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Order -> OrderItem : 일대다
+ * Order -> Member : 다대일
+ * */
+@Entity
+@Table(name = "orders")
+@Getter
+@Setter
+public class Order extends CreationEntity {
+	@Id
+	@Column(name = "id")
+	private String uuid;
+
+	@Enumerated(value = EnumType.STRING)
+	private OrderStatus orderStatus;
+
+	@Lob
+	private String memo;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", referencedColumnName = "id")
+	private Member member;
+
+	@OneToMany(mappedBy = "order",
+		cascade = CascadeType.ALL,
+		orphanRemoval = true)
+	private List<OrderItem> orderItems = new ArrayList<>();
+
+	protected Order() {
+	}
+
+	public Order(String uuid, OrderStatus orderStatus) {
+		this.uuid = uuid;
+		this.orderStatus = orderStatus;
+	}
+
+	public void orderedByMember(Member member) {
+		if (Objects.nonNull(this.member)) {
+			member.getOrders().remove(this);
+		}
+
+		this.member = member;
+		member.getOrders().add(this);
+	}
+
+	public void addOrderItem(OrderItem orderItem) {
+		this.orderItems.add(orderItem);
+
+		orderItem.addToOrder(this);
+	}
+}

--- a/src/main/java/com/example/springjpa/order/OrderItem.java
+++ b/src/main/java/com/example/springjpa/order/OrderItem.java
@@ -1,0 +1,58 @@
+package com.example.springjpa.order;
+
+import java.util.Objects;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "order_item")
+@Getter
+@Setter
+public class OrderItem extends CreationEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE)
+	private Long id;
+
+	private int quantity;
+	private int price;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "order_id", referencedColumnName = "id") // JPA 에게 자신이 참조하는 fk 에 대한 정보 알려줘야함
+	private Order order;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "item_id", referencedColumnName = "id")
+	private Item item;
+
+	protected OrderItem() {
+	}
+
+	public OrderItem(int quantity, Item item, int price) {
+		this.quantity = quantity;
+		this.item = item;
+		this.price = price;
+	}
+
+	public void addToOrder(Order order) {
+		if (Objects.nonNull(this.order)) {
+			this.order.getOrderItems().remove(this);
+		}
+
+		this.order = order;
+		order.getOrderItems().add(this);
+	}
+
+	public void setItem(Item item) {
+		this.item = item;
+	}
+}

--- a/src/main/java/com/example/springjpa/order/OrderStatus.java
+++ b/src/main/java/com/example/springjpa/order/OrderStatus.java
@@ -1,0 +1,6 @@
+package com.example.springjpa.order;
+
+public enum OrderStatus {
+	OPENED,
+	CANCELED
+}

--- a/src/test/java/com/example/springjpa/customer/CustomerJpaRepositoryTest.java
+++ b/src/test/java/com/example/springjpa/customer/CustomerJpaRepositoryTest.java
@@ -14,7 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @DataJpaTest
-@DisplayName("기본키 생성 전략이 SEQUENCE 일 때")
+@DisplayName("기본키 생성 전략이 SEQUENCE 일 때 JpaRepository 를 사용하여 테스트한다")
 class CustomerJpaRepositoryTest {
 	private static final Logger logger = LoggerFactory.getLogger(CustomerJpaRepositoryTest.class);
 

--- a/src/test/java/com/example/springjpa/customer/CustomerJpaRepositoryTest.java
+++ b/src/test/java/com/example/springjpa/customer/CustomerJpaRepositoryTest.java
@@ -5,8 +5,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
@@ -16,7 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 @DataJpaTest
 @DisplayName("기본키 생성 전략이 SEQUENCE 일 때 JpaRepository 를 사용하여 테스트한다")
 class CustomerJpaRepositoryTest {
-	private static final Logger logger = LoggerFactory.getLogger(CustomerJpaRepositoryTest.class);
 
 	@Autowired
 	private CustomerJpaRepository customerRepository;
@@ -31,7 +28,7 @@ class CustomerJpaRepositoryTest {
 
 	@AfterEach
 	void tearDown() {
-		logger.info("AfterEach 의 deleteAllInBatch 쿼리가 날아기기 전에 쓰기지연 저장소 내부 쿼리들이 날아간다");
+		log.info("AfterEach 의 deleteAllInBatch 쿼리가 날아기기 전에 쓰기지연 저장소 내부 쿼리들이 날아간다");
 		customerRepository.deleteAllInBatch();
 	}
 

--- a/src/test/java/com/example/springjpa/customer/CustomerPersistenceContextTest.java
+++ b/src/test/java/com/example/springjpa/customer/CustomerPersistenceContextTest.java
@@ -12,13 +12,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import lombok.extern.slf4j.Slf4j;
 
-@SpringBootTest
-@Transactional
+@DataJpaTest
 @DisplayName("기본키 생성 전략이 SEQUENCE 일 때 EntityManager 를 사용하여 테스트 한다")
 @Slf4j
 public class CustomerPersistenceContextTest {

--- a/src/test/java/com/example/springjpa/customer/CustomerPersistenceContextTest.java
+++ b/src/test/java/com/example/springjpa/customer/CustomerPersistenceContextTest.java
@@ -1,0 +1,174 @@
+package com.example.springjpa.customer;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityNotFoundException;
+import javax.persistence.EntityTransaction;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@DisplayName("기본키 생성 전략이 SEQUENCE 일 때 EntityManager 를 사용하여 테스트 한다")
+public class CustomerPersistenceContextTest {
+	private static final Logger logger = LoggerFactory.getLogger(CustomerPersistenceContextTest.class);
+
+	@Autowired
+	private EntityManagerFactory emf;
+
+	private EntityManager em;
+	private EntityTransaction tx;
+	private Customer customer;
+
+	@BeforeEach
+	void setUp() {
+		customer = createCustomer();
+		em = emf.createEntityManager();
+		tx = em.getTransaction();
+	}
+
+	private Customer createCustomer() {
+		return new Customer("abc", "mart");
+	}
+
+	@Test
+	@DisplayName("new 상태의 엔티티를 persist 하면 커밋 시 insert 된다")
+	public void persist_given_customer() {
+		tx.begin();
+		em.persist(customer);
+		tx.commit();
+	}
+
+	@Test
+	@DisplayName("new 상태의 엔티티를 merge 하면 커밋 시 insert 된다")
+	public void given_newEntity_when_merge_then_nothingHappen() {
+		tx.begin();
+
+		em.merge(customer);
+
+		tx.commit();
+	}
+
+	@Test
+	@DisplayName("merge 파라미터로 넘긴 엔티티를 변경하면 변경감지가 일어나지 않는다")
+	public void given_entityPassedByParameterToMerge_when_changeThatEntity_then_nothingHappen() {
+		tx.begin();
+
+		em.merge(customer);
+		customer.changeFirstName("kim");
+
+		tx.commit();
+	}
+
+	@Test
+	@DisplayName("merge 결과로 리턴되어온 엔티티를 변경하면 변경감지가 일어난다")
+	public void given_entityReturnedByMerge_when_changeThatEntity_then_update() {
+		tx.begin();
+
+		Customer persistedCustomer = em.merge(customer);
+		persistedCustomer.changeFirstName("kim");
+
+		tx.commit();
+	}
+
+	@Test
+	@DisplayName("영속화 했던 엔티티를 detach 하면 변경감지가 일어나지 않는다")
+	public void given_mergedEntity_when_detach_then_flushNotHappen() {
+		tx.begin();
+
+		Customer persistedCustomer = em.merge(customer);
+		em.detach(persistedCustomer);
+		persistedCustomer.changeFirstName("kim");
+
+		tx.commit();
+	}
+
+	@Test
+	@DisplayName("DB 에 저장되어 있는 엔티티에 대한 프록시 객체를 가져와 값을 변경하는 경우, 객체의 초기화가 일어나고 값이 변경된다")
+	public void given_proxy_when_change_then_initHappen() {
+		tx.begin();
+
+		// DB 에 저장 _insert
+		em.persist(customer);
+		em.flush();
+		// 영속성 컨텍스트를 비운다
+		em.clear();
+
+		// proxy
+		Customer proxy = em.getReference(Customer.class, customer.getId());
+		logger.info("Proxy 를 가져옴");
+
+		proxy.changeLastName("kim"); // 엔티티 초기화 - select
+
+		tx.commit();
+	}
+
+	@Test
+	@DisplayName("JPQL 쿼리를 날려 firstName 이 abc 로 시작하는 모든 커스토머를 가져와 그 개수를 확인한다")
+	public void given_customersName_when_findAllCustomers_then_success() {
+		tx.begin();
+
+		// 하나의 커스토머를 DB 에 저장 : INSERT
+		em.persist(customer);
+		em.flush();
+		// 영속성 컨텍스트를 비운다
+		em.clear();
+
+		// JPQL : SELECT
+		List<Customer> customers = em.createQuery("select c from Customer c where c.firstName like '%abc'",
+				Customer.class)
+			.getResultList();
+
+		Assertions.assertThat(customers.size()).isEqualTo(1);
+
+		tx.commit();
+	}
+
+	@Test
+	@DisplayName("DB 에 저장되어 있지 않은 엔티티에 대한 프록시 객체를 가져와 값을 변경하는 경우 객체의 초기화가 일어나며 예외가 발생한다")
+	public void given_proxy_when_change_then_exceptionThrown() {
+		tx.begin();
+		// sequence -> customer 인스턴스에 id 를 부여
+		em.persist(customer);
+		// 영속성 컨텍스트를 비우고 ( flush x 상태 에서 영속성 컨텍스트를 비워버림 )
+		em.clear();
+		// 프록시 객체 얻어오기 ( customer 는 id 를 갖고 있다 )
+		Customer proxy = em.getReference(Customer.class, customer.getId());
+
+		logger.info("Proxy 객체를 얻어옴");
+		// Entity 초기화 - DB 에는 저장되지 않았었기 때문에 예외가 발생한다
+		Assertions.assertThatThrownBy(() ->
+				proxy.changeFirstName("kim"))
+			.isInstanceOf(EntityNotFoundException.class);
+
+		tx.commit();
+	}
+
+	@Test
+	@DisplayName("find 를 통해 DB 로부터 영속화 된 엔티티를 찾아온다")
+	public void given_idAndType_when_find_then_success() {
+		tx.begin();
+
+		em.persist(customer);
+		em.flush();
+		em.clear();
+
+		Customer foundCustomer = em.find(Customer.class, this.customer.getId());
+
+		Assertions.assertThat(foundCustomer)
+			.usingRecursiveComparison()
+			.isEqualTo(this.customer);
+
+		tx.commit();
+	}
+}

--- a/src/test/java/com/example/springjpa/customer/CustomerPersistenceContextTest.java
+++ b/src/test/java/com/example/springjpa/customer/CustomerPersistenceContextTest.java
@@ -11,17 +11,17 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import lombok.extern.slf4j.Slf4j;
+
 @SpringBootTest
 @Transactional
 @DisplayName("기본키 생성 전략이 SEQUENCE 일 때 EntityManager 를 사용하여 테스트 한다")
+@Slf4j
 public class CustomerPersistenceContextTest {
-	private static final Logger logger = LoggerFactory.getLogger(CustomerPersistenceContextTest.class);
 
 	@Autowired
 	private EntityManagerFactory emf;
@@ -102,7 +102,7 @@ public class CustomerPersistenceContextTest {
 
 		// proxy
 		Customer proxy = em.getReference(Customer.class, customer.getId());
-		logger.info("Proxy 를 가져옴");
+		log.info("Proxy 를 가져옴");
 
 		proxy.changeLastName("kim"); // 엔티티 초기화 - select
 
@@ -141,7 +141,7 @@ public class CustomerPersistenceContextTest {
 		// 프록시 객체 얻어오기 ( customer 는 id 를 갖고 있다 )
 		Customer proxy = em.getReference(Customer.class, customer.getId());
 
-		logger.info("Proxy 객체를 얻어옴");
+		log.info("Proxy 객체를 얻어옴");
 		// Entity 초기화 - DB 에는 저장되지 않았었기 때문에 예외가 발생한다
 		Assertions.assertThatThrownBy(() ->
 				proxy.changeFirstName("kim"))

--- a/src/test/java/com/example/springjpa/customer/CustomerPersistenceContextTest.java
+++ b/src/test/java/com/example/springjpa/customer/CustomerPersistenceContextTest.java
@@ -37,10 +37,6 @@ public class CustomerPersistenceContextTest {
 		tx = em.getTransaction();
 	}
 
-	private Customer createCustomer() {
-		return new Customer("abc", "mart");
-	}
-
 	@Test
 	@DisplayName("new 상태의 엔티티를 persist 하면 커밋 시 insert 된다")
 	public void persist_given_customer() {
@@ -170,5 +166,9 @@ public class CustomerPersistenceContextTest {
 			.isEqualTo(this.customer);
 
 		tx.commit();
+	}
+
+	private Customer createCustomer() {
+		return new Customer("abc", "mart");
 	}
 }

--- a/src/test/java/com/example/springjpa/order/OrderTest.java
+++ b/src/test/java/com/example/springjpa/order/OrderTest.java
@@ -1,0 +1,163 @@
+package com.example.springjpa.order;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.UUID;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityTransaction;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class OrderTest {
+
+	@Autowired
+	private EntityManagerFactory emf;
+	private EntityManager em;
+	private EntityTransaction tx;
+
+	private Item chair;
+	private Item book;
+	private Member member;
+
+	@BeforeEach
+	void setUp() {
+		em = emf.createEntityManager();
+		tx = em.getTransaction();
+
+		tx.begin();
+
+		chair = new Furniture(1000, 100, 11, 11);
+		book = new Book(500, 50, "이상한 나라의 앨리스");
+		member = createMember();
+
+		em.persist(chair);
+		em.persist(book);
+		em.persist(member);
+
+		tx.commit();
+		em.clear();
+	}
+
+	@Test
+	@DisplayName("주문을 저장하면 orderItem 도 저장된다")
+	public void test_order() {
+		tx.begin();
+
+		Order order = createOrder();
+
+		em.persist(order);
+
+		tx.commit();
+	}
+
+	@Test
+	@DisplayName("주문 정보를 불러올 때 Member 는 초기화되지 않은 프록시 객체다")
+	public void test_proxy() {
+		tx.begin();
+
+		Order order = createOrder();
+
+		em.persist(order);
+		tx.commit();
+		em.clear();
+
+		tx.begin();
+
+		Order foundOrder = em.find(Order.class, order.getUuid().toString());
+		Member proxyMember = foundOrder.getMember();
+
+		assertThat(emf.getPersistenceUnitUtil().isLoaded(proxyMember)).isFalse();
+
+		tx.commit();
+	}
+
+	@Test
+	@DisplayName("주문 정보를 불러온 후 멤버에 접근한 이후에는 멤버는 초기화된 프록시 객체다")
+	public void test_not_proxy() {
+		tx.begin();
+
+		Order order = createOrder();
+
+		em.persist(order);
+		tx.commit();
+		em.clear();
+
+		tx.begin();
+
+		Order foundOrder = em.find(Order.class, order.getUuid().toString());
+
+		Member proxyMember = foundOrder.getMember();
+
+		String initializedProxyMemberName = proxyMember.getName(); // 초기화 발생
+
+		assertThat(emf.getPersistenceUnitUtil().isLoaded(proxyMember)).isTrue();
+
+		tx.commit();
+
+	}
+
+	@Test
+	@DisplayName("다대일 단방향 관계일 경우 일 의 삭제 요청 시 fk 제약조건을 위반하여 커밋과정에서 예외가 발생한다")
+	public void remove() {
+		tx.begin();
+
+		Order order = createOrder();
+
+		em.persist(order);
+		tx.commit();
+
+		tx.begin();
+
+		Item foundChair = em.find(Item.class, chair.getId());
+		em.remove(foundChair);
+
+		tx.commit(); // @Transactional 이기 때문에 롤백하는데 그 과정에서 fk 조건 위반 관련 에러가 발생하는 것이기에 rollBackException 이 발생한다
+
+	}
+
+	@Test
+	@DisplayName("일대 다에서 일 측의 CascadeType 에 REMOVE 가 포함되어있으며 orphanRemoval 이 true 면 일의 삭제 요청 시 다 측을 모두 삭제한 후 일을 삭제한다")
+	public void remove_member_test() {
+		tx.begin();
+
+		Order order = createOrder();
+
+		em.persist(order);
+		tx.commit();
+
+		tx.begin();
+
+		Order foundOrder = em.find(Order.class, order.getUuid());
+		em.remove(foundOrder);
+
+		tx.commit();
+	}
+
+	private Member createMember() {
+		return new Member("kimLee", "kirin", 33, "Triple street");
+	}
+
+	private Order createOrder() {
+		Order order = new Order(UUID.randomUUID().toString(), OrderStatus.OPENED);
+
+		OrderItem orderItem1 = new OrderItem(10, chair, 1000);
+		OrderItem orderItem2 = new OrderItem(4, book, 500);
+
+		order.orderedByMember(member);
+		order.addOrderItem(orderItem1);
+		order.addOrderItem(orderItem2);
+
+		return order;
+	}
+
+}


### PR DESCRIPTION
**과제**
- [x]  order, order_item, item 의 연관관계 매핑을 실습해본다.

![image](https://user-images.githubusercontent.com/53856184/168497943-890a093d-fd4a-4bc8-a3cf-77fef9e7a18a.png)

- OrderItem -> Order은 다대일 양방향관계  로, Order 에서는 OrderItem 과의 관계설정에서 CascadeType.REMOVE 와 orphanRemoval = true 설정을 하였음 
- OrderItem -> ITem 은 다대일 단방향관계 로 Item 에서는 OrderItem 과의 관계설정이 따로 되어있지 않다. 

따라서 Order 를 삭제하는 과정에서는 먼저 해당 Order 의 OrderItem 에 대한 삭제 이후 Order 를 삭제하여 예외가 발생하지 않으나
Item 을 삭제하는 과정에서는 Item 에서는 이를 참조하고 있는 OrderItem 에 대한 정보를 알지 못하기에 , OrderItem 에대한 삭제가 선행되지 않아 fk 위반 예외가 발생하는 것을 테스트 하였다.