### PR TITLE
[3기-C 김환] Mission 3: 연관관계 매핑

### DIFF
--- a/src/main/java/grepp/prgrms/springbootjpa/domain/BaseEntity.java
+++ b/src/main/java/grepp/prgrms/springbootjpa/domain/BaseEntity.java
@@ -1,0 +1,19 @@
+package grepp.prgrms.springbootjpa.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@MappedSuperclass
+public class BaseEntity {
+    @Column(name = "created_by")
+    private String createdBy;
+
+    @Column(name = "created_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/grepp/prgrms/springbootjpa/domain/item/Car.java
+++ b/src/main/java/grepp/prgrms/springbootjpa/domain/item/Car.java
@@ -1,0 +1,14 @@
+package grepp.prgrms.springbootjpa.domain.item;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@DiscriminatorValue("CAR")
+public class Car extends Item{
+    private int power;
+}

--- a/src/main/java/grepp/prgrms/springbootjpa/domain/item/Food.java
+++ b/src/main/java/grepp/prgrms/springbootjpa/domain/item/Food.java
@@ -1,0 +1,14 @@
+package grepp.prgrms.springbootjpa.domain.item;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@DiscriminatorValue("FOOD")
+public class Food extends Item {
+    private String chef;
+}

--- a/src/main/java/grepp/prgrms/springbootjpa/domain/item/Furniture.java
+++ b/src/main/java/grepp/prgrms/springbootjpa/domain/item/Furniture.java
@@ -1,0 +1,15 @@
+package grepp.prgrms.springbootjpa.domain.item;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@DiscriminatorValue("FURNITURE")
+public class Furniture extends Item{
+    private int width;
+    private int height;
+}

--- a/src/main/java/grepp/prgrms/springbootjpa/domain/item/Item.java
+++ b/src/main/java/grepp/prgrms/springbootjpa/domain/item/Item.java
@@ -1,0 +1,22 @@
+package grepp.prgrms.springbootjpa.domain.item;
+
+import grepp.prgrms.springbootjpa.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "DTYPE")
+@Table(name = "item")
+public abstract class Item extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long id;
+
+    private int price;
+    private int stockQuantity;
+}

--- a/src/main/java/grepp/prgrms/springbootjpa/domain/member/Member.java
+++ b/src/main/java/grepp/prgrms/springbootjpa/domain/member/Member.java
@@ -1,0 +1,86 @@
+package grepp.prgrms.springbootjpa.domain.member;
+
+import grepp.prgrms.springbootjpa.domain.BaseEntity;
+import grepp.prgrms.springbootjpa.domain.order.Order;
+import jakarta.persistence.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "member")
+public class Member extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 30)
+    private String name;
+
+    @Column(name = "nick_name", nullable = false, length = 30, unique = true)
+    private String nickName;
+
+    @Column(name = "age", nullable = false)
+    private int age;
+
+    @Column(name = "address", nullable = false)
+    private String address;
+
+    @Column(name = "description")
+    private String description;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Order> orders = new ArrayList<>();
+
+    public void createOrder(Order order){
+        order.mappingMember(this);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getNickName() {
+        return nickName;
+    }
+
+    public void setNickName(String nickName) {
+        this.nickName = nickName;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public List<Order> getOrders() {
+        return orders;
+    }
+}

--- a/src/main/java/grepp/prgrms/springbootjpa/domain/order/Order.java
+++ b/src/main/java/grepp/prgrms/springbootjpa/domain/order/Order.java
@@ -1,0 +1,57 @@
+package grepp.prgrms.springbootjpa.domain.order;
+
+import grepp.prgrms.springbootjpa.domain.BaseEntity;
+import grepp.prgrms.springbootjpa.domain.member.Member;
+import grepp.prgrms.springbootjpa.domain.orderitem.OrderItem;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "orders")
+public class Order extends BaseEntity {
+    @Id
+    @Column(name = "id")
+    private String uuid;
+
+    @Column(name = "name")
+    private String name;
+
+    @Enumerated(value = EnumType.STRING)
+    private OrderStatus orderStatus;
+
+    @Column(name = "order_datetime", columnDefinition = "TIMESTAMP")
+    private LocalDateTime orderDatetime;
+
+    @Column(name = "memo")
+    private String memo;
+
+    @Column(name = "member_id", insertable = false, updatable = false)
+    private Long memberId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", referencedColumnName = "id")
+    private Member member;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderItem> orderItems = new ArrayList<>();
+
+    public void mappingMember(Member member){
+        if(Objects.nonNull(this.member)){
+            member.getOrders().remove(this);
+        }
+        this.member = member;
+        member.getOrders().add(this);
+    }
+
+    public void addOrderItem(OrderItem orderItem) {
+        orderItem.mappingOrder(this);
+    }
+}

--- a/src/main/java/grepp/prgrms/springbootjpa/domain/order/OrderStatus.java
+++ b/src/main/java/grepp/prgrms/springbootjpa/domain/order/OrderStatus.java
@@ -1,0 +1,6 @@
+package grepp.prgrms.springbootjpa.domain.order;
+
+public enum OrderStatus {
+    OPENED,
+    CANCELED
+}

--- a/src/main/java/grepp/prgrms/springbootjpa/domain/orderitem/OrderItem.java
+++ b/src/main/java/grepp/prgrms/springbootjpa/domain/orderitem/OrderItem.java
@@ -1,0 +1,46 @@
+package grepp.prgrms.springbootjpa.domain.orderitem;
+
+import grepp.prgrms.springbootjpa.domain.BaseEntity;
+import grepp.prgrms.springbootjpa.domain.item.Item;
+import grepp.prgrms.springbootjpa.domain.order.Order;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Objects;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "order_item")
+public class OrderItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long id;
+
+    private int price;
+    private int quantity;
+
+    @Column(name = "order_id", insertable = false, updatable = false)
+    private String orderId;
+
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", referencedColumnName = "id")
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", referencedColumnName = "id")
+    private Item item;
+
+    public void mappingOrder(Order order){
+        if(Objects.nonNull(this.order)){
+            this.order.getOrderItems().remove(this);
+        }
+        this.order = order;
+        order.getOrderItems().add(this);
+    }
+}

--- a/src/main/java/grepp/prgrms/springbootjpa/domain/parent/Parent.java
+++ b/src/main/java/grepp/prgrms/springbootjpa/domain/parent/Parent.java
@@ -1,0 +1,13 @@
+package grepp.prgrms.springbootjpa.domain.parent;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+public class Parent {
+    @EmbeddedId
+    private ParentId id;
+}

--- a/src/main/java/grepp/prgrms/springbootjpa/domain/parent/ParentId.java
+++ b/src/main/java/grepp/prgrms/springbootjpa/domain/parent/ParentId.java
@@ -1,0 +1,19 @@
+package grepp.prgrms.springbootjpa.domain.parent;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+@Embeddable
+public class ParentId implements Serializable {
+    private String id1;
+    private String id2;
+}

--- a/src/test/java/grepp/prgrms/springbootjpa/domain/PersistenceContextTest.java
+++ b/src/test/java/grepp/prgrms/springbootjpa/domain/PersistenceContextTest.java
@@ -1,0 +1,176 @@
+package grepp.prgrms.springbootjpa.domain;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@SpringBootTest
+public class PersistenceContextTest {
+
+    @Autowired
+    CustomerRepository customerRepository;
+
+    @Autowired
+    EntityManagerFactory emf;
+
+    @AfterEach
+    void tearDown(){
+        customerRepository.deleteAll();
+    }
+
+    @Test
+    @Transactional
+    void insert(){
+        EntityManager em = emf.createEntityManager();
+        EntityTransaction transaction = em.getTransaction();
+
+        transaction.begin();
+
+        Customer customer = new Customer();
+        customer.changeId(1L);
+        customer.changeFirstName("first");
+        customer.changeLastName("last");
+
+        em.persist(customer);
+        em.flush();
+
+        transaction.commit();
+    }
+
+    @Test
+    @Transactional
+    void find_DB(){
+        EntityManager em = emf.createEntityManager();
+        EntityTransaction transaction = em.getTransaction();
+
+        transaction.begin();
+
+        Customer customer = new Customer();
+        customer.changeId(1L);
+        customer.changeFirstName("first");
+        customer.changeLastName("last");
+
+        em.persist(customer);
+
+        transaction.commit();
+
+        em.detach(customer);
+
+        Customer selected = em.find(Customer.class, 1L);
+        log.info("{} {}", selected.getFirstName(), selected.getLastName());
+    }
+
+    @Test
+    @Transactional
+    void use_cache(){
+
+        EntityManager em = emf.createEntityManager();
+        EntityTransaction transaction = em.getTransaction();
+
+        transaction.begin();
+
+        Customer customer = new Customer();
+        customer.changeId(1L);
+        customer.changeFirstName("first");
+        customer.changeLastName("last");
+
+        em.persist(customer);
+
+        transaction.commit();
+
+        Customer selected = em.find(Customer.class, 1L);
+        log.info("{} {}", selected.getFirstName(), selected.getLastName());
+    }
+
+    @Test
+    @Transactional
+    void update(){
+
+        EntityManager em = emf.createEntityManager();
+        EntityTransaction transaction = em.getTransaction();
+
+        transaction.begin();
+
+        Customer customer = new Customer();
+        customer.changeId(1L);
+        customer.changeFirstName("first");
+        customer.changeLastName("last");
+
+        em.persist(customer);
+
+        transaction.commit();
+
+        transaction.begin();
+        customer.changeFirstName("newfirst");
+        customer.changeLastName("newlast");
+
+        transaction.commit();
+    }
+
+    @Test
+    @Transactional
+    void delete(){
+
+        EntityManager em = emf.createEntityManager();
+        EntityTransaction transaction = em.getTransaction();
+
+        transaction.begin();
+
+        Customer customer = new Customer();
+        customer.changeId(1L);
+        customer.changeFirstName("first");
+        customer.changeLastName("last");
+        em.persist(customer);
+
+        transaction.commit();
+
+        transaction.begin();
+        em.remove(customer);
+        transaction.commit();
+    }
+
+    @Test
+    @Transactional
+    void 쓰기_지연(){
+
+        EntityManager em = emf.createEntityManager();
+        EntityTransaction transaction = em.getTransaction();
+
+        transaction.begin();
+
+
+        log.info("persist customer1");
+        Customer customer = new Customer();
+        customer.changeId(1L);
+        customer.changeFirstName("first1");
+        customer.changeLastName("last1");
+        em.persist(customer);
+
+        log.info("persist customer2");
+        Customer customer2 = new Customer();
+        customer2.changeId(2L);
+        customer2.changeFirstName("first2");
+        customer2.changeLastName("last2");
+        em.persist(customer2);
+
+        log.info("persist customer3");
+        Customer customer3 = new Customer();
+        customer3.changeId(3L);
+        customer3.changeFirstName("first2");
+        customer3.changeLastName("last2");
+        em.persist(customer3);
+
+        transaction.commit();
+
+        log.info("after commit");
+    }
+}

--- a/src/test/java/grepp/prgrms/springbootjpa/domain/entityMapping/EntityMappingTest.java
+++ b/src/test/java/grepp/prgrms/springbootjpa/domain/entityMapping/EntityMappingTest.java
@@ -1,0 +1,199 @@
+package grepp.prgrms.springbootjpa.domain.entityMapping;
+
+import grepp.prgrms.springbootjpa.domain.item.Food;
+import grepp.prgrms.springbootjpa.domain.item.Item;
+import grepp.prgrms.springbootjpa.domain.member.Member;
+import grepp.prgrms.springbootjpa.domain.order.Order;
+import grepp.prgrms.springbootjpa.domain.order.OrderStatus;
+import grepp.prgrms.springbootjpa.domain.orderitem.OrderItem;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+
+@Slf4j
+@DataJpaTest
+public class EntityMappingTest {
+
+    @Autowired
+    EntityManagerFactory emf;
+
+    @Test
+    public void 사용자가_주문_생성(){
+        //given
+        EntityManager entityManager = emf.createEntityManager();
+        EntityTransaction transaction = entityManager.getTransaction();
+        transaction.begin();
+
+        Member member = new Member();
+        member.setAge(20);
+        member.setNickName("hwankim123");
+        member.setName("김환");
+        member.setAddress("경기도 성남시 어쩌구");
+        member.setDescription("김환입니다");
+        member.setCreatedAt(LocalDateTime.now());
+        member.setCreatedBy("hwankim123");;
+
+        entityManager.persist(member);
+
+        //when
+        Order order = new Order();
+        String uuid = UUID.randomUUID().toString();
+        order.setOrderStatus(OrderStatus.OPENED);
+        order.setOrderDatetime(LocalDateTime.now());
+        order.setMemo("맛있는 라면을 삽시다");
+        order.setUuid(uuid);
+
+        Member findMember = entityManager.find(Member.class, member.getId());
+        findMember.createOrder(order);
+
+        log.info("transaction committed");
+        transaction.commit();
+
+        //then
+        Order findOrder = entityManager.find(Order.class, uuid);
+        Member memberOrdered = findOrder.getMember();
+        assertThat(memberOrdered.getName()).isEqualTo("김환");
+
+    }
+
+    @Test
+    public void 상품까지_연결된_주문_생성(){
+        //given
+        EntityManager entityManager = emf.createEntityManager();
+        EntityTransaction transaction = entityManager.getTransaction();
+        transaction.begin();
+
+        Item item = new Food();
+        item.setPrice(1000);
+        item.setStockQuantity(20);
+
+        entityManager.persist(item);
+
+        Order order = new Order();
+        String uuid = UUID.randomUUID().toString();
+        order.setUuid(uuid);
+        order.setOrderStatus(OrderStatus.OPENED);
+        order.setOrderDatetime(LocalDateTime.now());
+        order.setMemo("맛있는 라면을 삽시다");
+
+        entityManager.persist(order);
+
+        //when
+        OrderItem orderItem = new OrderItem();
+        orderItem.setPrice(1000);
+        orderItem.setQuantity(12);
+        order.addOrderItem(orderItem);
+
+        entityManager.persist(order);
+
+        transaction.commit();
+        log.info("transaction committed");
+
+        //then
+        Order findOrder = entityManager.find(Order.class, uuid);
+        List<OrderItem> orderItems = findOrder.getOrderItems();
+        assertThat(orderItems.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void 영속성_삭제_전이(){
+        //given
+        EntityManager entityManager = emf.createEntityManager();
+        EntityTransaction transaction = entityManager.getTransaction();
+        transaction.begin();
+
+        Item item = new Food();
+        item.setPrice(1000);
+        item.setStockQuantity(20);
+
+        entityManager.persist(item);
+
+        Order order = new Order();
+        String uuid = UUID.randomUUID().toString();
+        order.setUuid(uuid);
+        order.setOrderStatus(OrderStatus.OPENED);
+        order.setOrderDatetime(LocalDateTime.now());
+        order.setMemo("맛있는 라면을 삽시다");
+
+        entityManager.persist(order);
+
+        OrderItem orderItem = new OrderItem();
+        orderItem.setPrice(1000);
+        orderItem.setQuantity(12);
+        order.addOrderItem(orderItem);
+        entityManager.persist(order);
+
+        transaction.commit();
+        Long orderItemId = orderItem.getId();
+        log.info("transaction committed");
+
+        //when
+        transaction.begin();
+
+        Order findOrder = entityManager.find(Order.class, uuid);
+        entityManager.remove(findOrder);
+
+        transaction.commit();
+        log.info("transaction committed");
+
+        //then
+        Order findAfterDeleteOrder = entityManager.find(Order.class, uuid);
+        assertThat(findAfterDeleteOrder).isEqualTo(null);
+        OrderItem findAfterDeleteOrderItem = entityManager.find(OrderItem.class, orderItemId);
+        assertThat(findAfterDeleteOrderItem).isEqualTo(null);
+    }
+
+    @Test
+    public void 고아객체_삭제(){
+        //given
+        EntityManager entityManager = emf.createEntityManager();
+        EntityTransaction transaction = entityManager.getTransaction();
+        transaction.begin();
+
+        Item item = new Food();
+        item.setPrice(1000);
+        item.setStockQuantity(20);
+
+        entityManager.persist(item);
+
+        Order order = new Order();
+        String uuid = UUID.randomUUID().toString();
+        order.setUuid(uuid);
+        order.setOrderStatus(OrderStatus.OPENED);
+        order.setOrderDatetime(LocalDateTime.now());
+        order.setMemo("맛있는 라면을 삽시다");
+
+        entityManager.persist(order);
+
+        OrderItem orderItem = new OrderItem();
+        orderItem.setPrice(1000);
+        orderItem.setQuantity(12);
+        order.addOrderItem(orderItem);
+        entityManager.persist(order);
+
+        transaction.commit();
+        Long orderItemId = orderItem.getId();
+        log.info("transaction committed");
+
+        //when
+        transaction.begin();
+        order.getOrderItems().remove(orderItem);
+        transaction.commit();
+        log.info("transaction committed");
+
+        //then
+        OrderItem deletedOrderItem = entityManager.find(OrderItem.class, orderItemId);
+        assertThat(deletedOrderItem).isEqualTo(null);
+
+    }
+}


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
* 연관관계 매핑을 실습해보았습니다.
* Member와 Order는 1 : N 양방향 연관관계를 갖습니다.
* Order와 OrderItem은 1:N 양방향 연관관계를 갖습니다.
* OrderItem과 Item은 N:1 단방향 연관관계를 갖습니다.(OrderItem에서만 Item을 참조합니다)
* 연관관계 매핑 및 영속성 전이를 테스트해보았습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
양방향 연관관계 매핑에서 연관관계 편의 메서드를 작성해야 함을 배웠습니다.
그런데, 연관관계 편의 메서드를 연관관계의 주인쪽에만 작성해야 할지, 아니면 양쪽에 모두 작성해야 할지
그 기준이 아직 모호합니다. 의견 궁금합니다!
