### PR TITLE
[4기 황준호] JPA : Mission 1 제출입니다.

### DIFF
--- a/kdt-jpa/.gitignore
+++ b/kdt-jpa/.gitignore
@@ -1,0 +1,42 @@
+### Additional gitignore
+gradlew.bat
+gradlew
+gradle
+
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/

--- a/kdt-jpa/build.gradle
+++ b/kdt-jpa/build.gradle
@@ -1,0 +1,43 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.1.2'
+    id 'io.spring.dependency-management' version '1.1.2'
+}
+
+group = 'com.kdt'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    sourceCompatibility = '17'
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // JDBC API, JDBC
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc:'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // MYBATIS
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.2'
+    testImplementation 'org.projectlombok:lombok:'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.2'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/kdt-jpa/settings.gradle
+++ b/kdt-jpa/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'kdt-jpa'

--- a/kdt-jpa/src/main/java/com/kdt/kdtjpa/KdtJpaApplication.java
+++ b/kdt-jpa/src/main/java/com/kdt/kdtjpa/KdtJpaApplication.java
@@ -1,0 +1,13 @@
+package com.kdt.kdtjpa;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class KdtJpaApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(KdtJpaApplication.class, args);
+    }
+
+}

--- a/kdt-jpa/src/main/java/com/kdt/kdtjpa/config/DataSourceConfig.java
+++ b/kdt-jpa/src/main/java/com/kdt/kdtjpa/config/DataSourceConfig.java
@@ -1,0 +1,64 @@
+package com.kdt.kdtjpa.config;
+
+import org.springframework.boot.autoconfigure.orm.jpa.JpaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.JpaVendorAdapter;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.AbstractJpaVendorAdapter;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.sql.DataSource;
+import java.util.Properties;
+
+@Configuration
+@EnableJpaRepositories(basePackages = "com.kdt.kdtjpa.domain")
+public class DataSourceConfig {
+
+    @Bean
+    public DataSource dataSource() {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUrl("jdbc:h2:~/test");
+        dataSource.setUsername("sa");
+        dataSource.setPassword("");
+        return dataSource;
+    }
+
+    @Bean
+    public JpaVendorAdapter jpaVendorAdapter(JpaProperties jpaProperties) {
+        AbstractJpaVendorAdapter adapter = new HibernateJpaVendorAdapter();
+        adapter.setShowSql(jpaProperties.isShowSql());
+        adapter.setDatabasePlatform(jpaProperties.getDatabasePlatform());
+        adapter.setGenerateDdl(jpaProperties.isGenerateDdl());
+        return adapter;
+    }
+
+    @Bean
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory(DataSource dataSource, JpaVendorAdapter jpaVendorAdapter,
+                                                                       JpaProperties jpaProperties) {
+        LocalContainerEntityManagerFactoryBean em
+                = new LocalContainerEntityManagerFactoryBean();
+        em.setDataSource(dataSource);
+        em.setPackagesToScan("com.kdt.kdtjpa.domain");
+        em.setJpaVendorAdapter(jpaVendorAdapter);
+
+        Properties properties = new Properties();
+        properties.putAll(jpaProperties.getProperties());
+        em.setJpaProperties(properties);
+
+        return em;
+    }
+
+     @Bean
+    public PlatformTransactionManager transactionManager(LocalContainerEntityManagerFactoryBean entityManagerFactory) {
+        JpaTransactionManager transactionManager = new JpaTransactionManager();
+        transactionManager.setEntityManagerFactory(entityManagerFactory.getObject());
+
+        return transactionManager;
+    }
+}

--- a/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/Customer.java
+++ b/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/Customer.java
@@ -3,12 +3,14 @@ package com.kdt.kdtjpa.domain;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
 @Entity
 @Table(name = "customers")
 @Getter @Setter
+@EqualsAndHashCode
 public class Customer {
     @Id
     private long id;

--- a/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/Customer.java
+++ b/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/Customer.java
@@ -1,0 +1,17 @@
+package com.kdt.kdtjpa.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "customers")
+@Getter @Setter
+public class Customer {
+    @Id
+    private long id;
+    private String firstName;
+    private String lastName;
+}

--- a/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/Customer.java
+++ b/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/Customer.java
@@ -1,19 +1,37 @@
 package com.kdt.kdtjpa.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
+import jakarta.persistence.*;
+import lombok.*;
 
 @Entity
 @Table(name = "customers")
-@Getter @Setter
+@Getter
 @EqualsAndHashCode
+@NoArgsConstructor(access =AccessLevel.PROTECTED)
 public class Customer {
+
     @Id
     private long id;
-    private String firstName;
-    private String lastName;
+    @Embedded
+    @AttributeOverride(name = "name", column = @Column(name = "first_name"))
+    private Name firstName;
+
+    @Embedded
+    @AttributeOverride(name = "name", column = @Column(name = "last_name"))
+    private Name lastName;
+
+    @Builder(builderMethodName = "createCustomer")
+    public Customer(long id, String firstName, String lastName) {
+        this.id = id;
+        this.firstName = new Name(firstName);
+        this.lastName = new Name(lastName);
+    }
+
+    public void changeFirstName(String firstName) {
+        this.firstName = new Name(firstName);
+    }
+
+    public void changeLastName(String lastName) {
+        this.lastName = new Name(lastName);
+    }
 }

--- a/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/Customer.java
+++ b/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/Customer.java
@@ -5,7 +5,6 @@ import lombok.*;
 
 @Entity
 @Table(name = "customers")
-@Getter
 @EqualsAndHashCode
 @NoArgsConstructor(access =AccessLevel.PROTECTED)
 public class Customer {

--- a/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/CustomerRepository.java
+++ b/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/CustomerRepository.java
@@ -1,0 +1,6 @@
+package com.kdt.kdtjpa.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CustomerRepository extends JpaRepository<Customer, Long> {
+}

--- a/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/Name.java
+++ b/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/Name.java
@@ -1,0 +1,25 @@
+package com.kdt.kdtjpa.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Name {
+
+    private String name;
+
+    public Name(String name) {
+        validateName(name);
+        this.name = name;
+    }
+
+    private void validateName(String name) {
+        if (name.isBlank()) {
+            throw new IllegalArgumentException("이름을 공백으로 생성할 수 없습니다.");
+        }
+    }
+}

--- a/kdt-jpa/src/main/resources/application.yml
+++ b/kdt-jpa/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  h2:
+    console:
+      enabled: true
+  jpa:
+    generate-ddl: true
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    database: h2
+    open-in-view: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        query.in_clause_parameter_padding: true

--- a/kdt-jpa/src/test/java/com/kdt/kdtjpa/JPATest.java
+++ b/kdt-jpa/src/test/java/com/kdt/kdtjpa/JPATest.java
@@ -4,6 +4,7 @@ import com.kdt.kdtjpa.domain.Customer;
 import com.kdt.kdtjpa.domain.CustomerRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -27,6 +28,7 @@ public class JPATest {
         repository.deleteAll();
     }
 
+    @DisplayName("Customer 객체를 저장하고 조회하면 같은 값을 보장한다.")
     @Test
     void insert_test() {
         // Given
@@ -43,6 +45,7 @@ public class JPATest {
         assertThat(customer).isEqualTo(entity);
     }
 
+    @DisplayName("Customer 값이 없는데 조회하면 예외를 발생한다.")
     @Test
     void find_test() {
         // When, Then
@@ -50,6 +53,7 @@ public class JPATest {
                 .isInstanceOf(NoSuchElementException.class);
     }
 
+    @DisplayName("Customer 값을 update한 다음 조회하면 같은 객체를 보장한다.")
     @Test
     void update_test() {
         // Given
@@ -69,6 +73,7 @@ public class JPATest {
         assertThat(entity).isEqualTo(updated);
     }
 
+    @DisplayName("Customer 객체를 저장, 삭제 후 조회 하면 예외가 발생한다.")
     @Test
     void delete_test() {
         // Given

--- a/kdt-jpa/src/test/java/com/kdt/kdtjpa/JPATest.java
+++ b/kdt-jpa/src/test/java/com/kdt/kdtjpa/JPATest.java
@@ -1,0 +1,88 @@
+package com.kdt.kdtjpa;
+
+import com.kdt.kdtjpa.domain.Customer;
+import com.kdt.kdtjpa.domain.CustomerRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Slf4j
+@SpringBootTest
+@Transactional
+public class JPATest {
+
+    @Autowired
+    CustomerRepository repository;
+
+    @AfterEach
+    void tearDown() {
+        repository.deleteAll();
+    }
+
+    @Test
+    void insert_test() {
+        // Given
+        Customer customer = new Customer();
+        customer.setId(1L);
+        customer.setFirstName("junho");
+        customer.setLastName("hwang");
+
+        // When
+        repository.save(customer);
+
+        // Then
+        Customer entity = repository.findById(1L).orElseThrow();
+        assertThat(customer).isEqualTo(entity);
+    }
+
+    @Test
+    void find_test() {
+        // When, Then
+        assertThatThrownBy(() -> repository.findById(1L).orElseThrow())
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    void update_test() {
+        // Given
+        Customer customer = new Customer();
+        customer.setId(1L);
+        customer.setFirstName("junho");
+        customer.setLastName("hwang");
+        repository.save(customer);
+
+        // When
+        Customer entity = repository.findById(1L).orElseThrow();
+        entity.setFirstName("backend");
+        entity.setLastName("programmers");
+
+        // Then
+        Customer updated = repository.findById(1L).orElseThrow();
+        assertThat(entity).isEqualTo(updated);
+    }
+
+    @Test
+    void delete_test() {
+        // Given
+        Customer customer = new Customer();
+        customer.setId(1L);
+        customer.setFirstName("junho");
+        customer.setLastName("hwang");
+        repository.save(customer);
+
+        // When
+        repository.delete(customer);
+
+        // Then
+        assertThatThrownBy(() -> repository.findById(1L).orElseThrow())
+                .isInstanceOf(NoSuchElementException.class);
+    }
+}

--- a/kdt-jpa/src/test/java/com/kdt/kdtjpa/domain/JPATest.java
+++ b/kdt-jpa/src/test/java/com/kdt/kdtjpa/domain/JPATest.java
@@ -1,6 +1,5 @@
 package com.kdt.kdtjpa.domain;
 
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,7 +12,6 @@ import java.util.NoSuchElementException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@Slf4j
 @SpringBootTest
 @Transactional
 public class JPATest {

--- a/kdt-jpa/src/test/java/com/kdt/kdtjpa/domain/JPATest.java
+++ b/kdt-jpa/src/test/java/com/kdt/kdtjpa/domain/JPATest.java
@@ -1,7 +1,5 @@
-package com.kdt.kdtjpa;
+package com.kdt.kdtjpa.domain;
 
-import com.kdt.kdtjpa.domain.Customer;
-import com.kdt.kdtjpa.domain.CustomerRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -32,10 +30,11 @@ public class JPATest {
     @Test
     void insert_test() {
         // Given
-        Customer customer = new Customer();
-        customer.setId(1L);
-        customer.setFirstName("junho");
-        customer.setLastName("hwang");
+        Customer customer = Customer.createCustomer()
+                .id(1L)
+                .lastName("Hwang")
+                .firstName("Junho")
+                .build();
 
         // When
         repository.save(customer);
@@ -57,16 +56,17 @@ public class JPATest {
     @Test
     void update_test() {
         // Given
-        Customer customer = new Customer();
-        customer.setId(1L);
-        customer.setFirstName("junho");
-        customer.setLastName("hwang");
+        Customer customer = Customer.createCustomer()
+                .id(1L)
+                .lastName("Hwang")
+                .firstName("Junho")
+                .build();
         repository.save(customer);
 
         // When
         Customer entity = repository.findById(1L).orElseThrow();
-        entity.setFirstName("backend");
-        entity.setLastName("programmers");
+        entity.changeFirstName("Kim");
+        entity.changeLastName("Happy");
 
         // Then
         Customer updated = repository.findById(1L).orElseThrow();
@@ -77,10 +77,11 @@ public class JPATest {
     @Test
     void delete_test() {
         // Given
-        Customer customer = new Customer();
-        customer.setId(1L);
-        customer.setFirstName("junho");
-        customer.setLastName("hwang");
+        Customer customer = Customer.createCustomer()
+                .id(1L)
+                .lastName("Hwang")
+                .firstName("Junho")
+                .build();
         repository.save(customer);
 
         // When

--- a/kdt-jpa/src/test/java/com/kdt/kdtjpa/domain/NameTest.java
+++ b/kdt-jpa/src/test/java/com/kdt/kdtjpa/domain/NameTest.java
@@ -21,8 +21,8 @@ class NameTest {
 
     @DisplayName("값이 같으면 Name 객체의 동등성을 보장한다.")
     @Test
-    void equals_and_HashCode() {
-        // Given,When
+    void when_nameValueIsSame_Expects_SameObject() {
+        // Given, When
         Name name1 = new Name("Hwang");
         Name name2 = new Name("Hwang");
 
@@ -33,8 +33,8 @@ class NameTest {
 
     @DisplayName("값이 같으면 Name 객체의 동등성을 보장하지 않는다.")
     @Test
-    void equals_and_HashCode2() {
-        // Given,When
+    void when_nameValueIsNotSame_Expects_DifferentObject() {
+        // Given, When
         Name name1 = new Name("Hwang");
         Name name2 = new Name("Kim");
 

--- a/kdt-jpa/src/test/java/com/kdt/kdtjpa/domain/NameTest.java
+++ b/kdt-jpa/src/test/java/com/kdt/kdtjpa/domain/NameTest.java
@@ -1,0 +1,45 @@
+package com.kdt.kdtjpa.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NameTest {
+
+    @DisplayName("이름이 공백일 경우 예외를 발생한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"", "  ", "          "})
+    void validateBlank(String name) {
+        // Given, When, Then
+        assertThatThrownBy(() -> new Name(name))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("값이 같으면 Name 객체의 동등성을 보장한다.")
+    @Test
+    void equals_and_HashCode() {
+        // Given,When
+        Name name1 = new Name("Hwang");
+        Name name2 = new Name("Hwang");
+
+        // Then
+        assertThat(name1).isEqualTo(name2);
+        assertThat(name1).hasSameHashCodeAs(name2);
+    }
+
+    @DisplayName("값이 같으면 Name 객체의 동등성을 보장하지 않는다.")
+    @Test
+    void equals_and_HashCode2() {
+        // Given,When
+        Name name1 = new Name("Hwang");
+        Name name2 = new Name("Kim");
+
+        // Then
+        assertThat(name1).isNotEqualTo(name2);
+        assertThat(name1).doesNotHaveSameHashCodeAs(name2);
+    }
+}


### PR DESCRIPTION
## 📌 과제 설명

**미션 1.**
- JPA 프로젝트를 세팅해 본다.
    - 세팅한 프로젝트를 이용해서 단일 엔티티를 이용한 CRUD를 구현한다.
    - 고객(Customer) 엔티티는 id, 이름, 성을 가진다.
    - 고객 엔티티를 이용한 CRUD를 구현한다.

## 👩‍💻 요구 사항과 구현 내용 

- 프로젝트를 gradle을 통해 생성했습니다. (xml을 사용하지 않고 maven보다  성능이 좋기 때문에)
- gitignore 설정을 통해 불필요한 파일을 제거했습니다.
- Customer Entity를 만들었고, JpaRepository를 통해 Repository를 생성했습니다.
- CRUD를 테스트하는 테스트 메서드를 작성했습니다.

---

-  setter와 getter 사용을 지양했습니다.
- Name 값 객체로 분리 하여 Name 객체에서 이름에 대한 검증 로직을 작성했습니다.
- Name 값 객체에 대한 테스트를 작성했습니다.
- Customer 엔티티에서 setter를 없앴고, 생성자 보다 보다 명확한 의미 전달을 위해 builder 패턴을 사용했습니다.


## ✅ PR 포인트 & 궁금한 점 

- 커밋 메세지를 잘 작성하려 했습니다.
- DisplayName을 통해 가독성을 높히려 노력했습니다.
- 롬복의 `@builder `의 작동 원리는 어떻게 될까요?
- 롬복의 `@EqualsAndHashCode`의 작동방식은 어떻게 되는 것일까요?
- application.yml의 설정 값들은 각각 어떤 의미를 가지고 있을까요?
- 값 객체 embedded, embeddable은 다음 링크를 참고했습니다 [링크](https://living-only-today.tistory.com/261)
