### PR TITLE
[4기 최성원] - update 테스트, dirty checking 실제 확인

### DIFF
--- a/src/main/java/com/kdt/mission1/domain/Customer.java
+++ b/src/main/java/com/kdt/mission1/domain/Customer.java
@@ -1,6 +1,7 @@
 package com.kdt.mission1.domain;
 
 import lombok.Getter;
+import lombok.Setter;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -8,14 +9,21 @@ import javax.persistence.Id;
 
 @Entity
 @Getter
+@Setter
 public class Customer {
-    @Id @GeneratedValue
-    private long id;
+    @Id
+    @GeneratedValue
+    private Long id;
     private String firstName;
     private String lastName;
 
-    public Customer(long id, String firstName, String lastName) {
+    public Customer(Long id, String firstName, String lastName) {
         this.id = id;
+        this.firstName = firstName;
+        this.lastName = lastName;
+    }
+
+    public Customer(String firstName, String lastName) {
         this.firstName = firstName;
         this.lastName = lastName;
     }

--- a/src/test/java/com/kdt/mission1/domain/CustomerRepositoryTest.java
+++ b/src/test/java/com/kdt/mission1/domain/CustomerRepositoryTest.java
@@ -1,48 +1,41 @@
 package com.kdt.mission1.domain;
 
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.annotation.Rollback;
-import org.springframework.transaction.annotation.Transactional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.samePropertyValuesAs;
 
-@SpringBootTest
-@TestMethodOrder(value = MethodOrderer.OrderAnnotation.class)
+@DataJpaTest
 @Rollback(value = false)
-@Transactional
 class CustomerRepositoryTest {
 
     @Autowired
     private CustomerRepository repository;
 
-//    @BeforeEach
-//    void setup() {
-//        repository.deleteAll();
-//    }
 
     @Test
     @DisplayName("객체를 저장할 수 있다")
-    @Order(1)
     public void testSave() {
         // Given
-        Customer customer = new Customer(1L, "seongwon", "choi");
+        Customer customer = new Customer("seongwon", "choi");
         // When
-        repository.save(customer);
+        Customer saved = repository.save(customer);
         // Then
-        Customer persistCustomer = repository.findById(1L).get();
+        Customer persistCustomer = repository.findById(saved.getId()).get();
         assertThat(customer, samePropertyValuesAs(persistCustomer));
 
     }
 
     @Test
     @DisplayName("저장된 객체를 수정해 다시 저장할 수 있다")
-    @Order(2)
     void testUpdate() {
         // Given
-        Customer customer = new Customer(2L, "seongwon", "choi");
+        Customer customer = new Customer("seongwon", "choi");
+        repository.save(customer);
         Customer persistCustomer = repository.findById(customer.getId()).get();
         // When
         persistCustomer.setFirstName("jerry");
@@ -56,7 +49,6 @@ class CustomerRepositoryTest {
 
     @Test
     @DisplayName("dirty check 를 통해 save 없이 객체를 수정할 수 있다")
-    @Order(3)
     void testDirtyCheckingUpdate() {
 
         // Given

--- a/src/test/java/com/kdt/mission1/domain/CustomerRepositoryTest.java
+++ b/src/test/java/com/kdt/mission1/domain/CustomerRepositoryTest.java
@@ -43,7 +43,6 @@ class CustomerRepositoryTest {
     void testUpdate() {
         // Given
         Customer customer = new Customer(2L, "seongwon", "choi");
-        Customer saved = repository.save(customer);
         Customer persistCustomer = repository.findById(customer.getId()).get();
         // When
         persistCustomer.setFirstName("jerry");

--- a/src/test/java/com/kdt/mission1/domain/CustomerRepositoryTest.java
+++ b/src/test/java/com/kdt/mission1/domain/CustomerRepositoryTest.java
@@ -1,19 +1,31 @@
 package com.kdt.mission1.domain;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.samePropertyValuesAs;
 
 @SpringBootTest
+@TestMethodOrder(value = MethodOrderer.OrderAnnotation.class)
+@Rollback(value = false)
+@Transactional
 class CustomerRepositoryTest {
 
     @Autowired
     private CustomerRepository repository;
 
+//    @BeforeEach
+//    void setup() {
+//        repository.deleteAll();
+//    }
+
     @Test
+    @DisplayName("객체를 저장할 수 있다")
+    @Order(1)
     public void testSave() {
         // Given
         Customer customer = new Customer(1L, "seongwon", "choi");
@@ -22,5 +34,42 @@ class CustomerRepositoryTest {
         // Then
         Customer persistCustomer = repository.findById(1L).get();
         assertThat(customer, samePropertyValuesAs(persistCustomer));
+
     }
+
+    @Test
+    @DisplayName("저장된 객체를 수정해 다시 저장할 수 있다")
+    @Order(2)
+    void testUpdate() {
+        // Given
+        Customer customer = new Customer(2L, "seongwon", "choi");
+        Customer saved = repository.save(customer);
+        Customer persistCustomer = repository.findById(customer.getId()).get();
+        // When
+        persistCustomer.setFirstName("jerry");
+        persistCustomer.setLastName("tom");
+        repository.save(persistCustomer);
+
+        // Then
+        Customer newCustomer = repository.findById(persistCustomer.getId()).get();
+        assertThat(newCustomer, samePropertyValuesAs(persistCustomer));
+    }
+
+    @Test
+    @DisplayName("dirty check 를 통해 save 없이 객체를 수정할 수 있다")
+    @Order(3)
+    void testDirtyCheckingUpdate() {
+
+        // Given
+        Customer customer = new Customer("seongwon", "choi");
+        Customer saved = repository.save(customer);
+        Customer persistCustomer = repository.findById(saved.getId()).get();
+        // When
+        persistCustomer.setFirstName("jerry");
+
+        // Then
+        Customer newCustomer = repository.findById(persistCustomer.getId()).get();
+        assertThat(newCustomer, samePropertyValuesAs(persistCustomer));
+    }
+
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,10 +4,10 @@ spring:
       enabled: true
   jpa:
     generate-ddl: true
-    hibernate:
-      ddl-auto: create-drop
     show-sql: true
     open-in-view: false
     properties:
       hibernate:
         format_sql: true
+        hbm2ddl:
+          auto: create-drop


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 단일 객체의 CRUD 테스트 구현

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 업데이트 테스트
- dirty checking 을 통해 실제로 update 쿼리가 나가는지 확인
  - 쿼리를 보기 위해 @transactional, @Rollback(value = false) 를 적용하였음
  - 트랜잭션이 rollback 이 아닌 commit 이 되어야 쿼리가 나가므로

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
- @DataJpaTest 어노테이션 반영 예정

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- ID 자동 생성 전략 설정 후 ID 타입이 래퍼 타입일 때 JPA가 다음 상황별로 조금씩 다르게 동작했습니다.
  - ID 값을 직접 설정하는 경우
  - ID 값을 null로 설정하는 경우
  - ID 값이 없는 생성자로 객체를 생성하는 경우
- 각 상황별 차이점에 대해 참고자료가 있으시면 공유해주시면 감사하겠습니다
