### PR TITLE
[4기 황준호]JPA : Mission 3 제출입니다.

### DIFF
--- a/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/order/BaseEntity.java
+++ b/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/order/BaseEntity.java
@@ -1,0 +1,17 @@
+package com.kdt.kdtjpa.domain.order;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseEntity {
+    @Column(name = "created_by")
+    private String createdBy;
+
+    @Column(name = "created_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+}

--- a/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/order/Item.java
+++ b/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/order/Item.java
@@ -1,0 +1,34 @@
+package com.kdt.kdtjpa.domain.order;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Objects;
+
+@Entity
+@Table(name = "item")
+@Getter
+@Setter
+@DiscriminatorColumn(name = "DTYPE")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+public abstract class Item extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long id;
+
+    private int price;
+    private int stockQuantity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_item_id", referencedColumnName = "id")
+    private OrderItem orderItem;
+
+    public void setOrderItem(OrderItem orderItem) {
+        if (Objects.nonNull(this.orderItem)) {
+            this.orderItem.getItems().remove(this);
+        }
+        this.orderItem = orderItem;
+        orderItem.getItems().add(this);
+    }
+}

--- a/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/order/Member.java
+++ b/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/order/Member.java
@@ -1,0 +1,38 @@
+package com.kdt.kdtjpa.domain.order;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "member")
+@Getter
+public class Member extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 30)
+    private String name;
+
+    @Column(name = "nick_name", nullable = false, length = 30, unique = true)
+    private String nickName;
+
+    @Column(name = "age", nullable = false)
+    private int age;
+
+    @Column(name = "address", nullable = false)
+    private String address;
+
+    @Column(name = "description")
+    private String description;
+
+    @OneToMany(mappedBy = "member") // 연관관계 주인 설정
+    private List<Order> orders = new ArrayList<>();
+
+    public void addOrder(Order order) { // 연관관계 편의 메서드
+        order.setMember(this);
+    }
+}

--- a/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/order/Order.java
+++ b/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/order/Order.java
@@ -1,0 +1,45 @@
+package com.kdt.kdtjpa.domain.order;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+
+@Entity
+@Table(name = "orders")
+@Getter
+public class Order extends BaseEntity {
+    @Id
+    @Column(name = "id")
+    private String uuid;
+
+    @Lob
+    private String memo;
+
+    @Enumerated(value = EnumType.STRING)
+    private OrderStatus orderStatus;
+
+    @Column(name = "order_datetime", columnDefinition = "TIMESTAMP")
+    private LocalDateTime orderDateTime;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "memeber_id", referencedColumnName = "id")
+    private Member member;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    List<OrderItem> orderItems;
+
+    public void setMember(Member member) {
+        if (Objects.nonNull(this.member)) {
+            member.getOrders().remove(this);
+        }
+        this.member = member;
+        member.getOrders().add(this);
+    }
+
+    public void addOrderItem(OrderItem orderItem) {
+        orderItem.setOrder(this);
+    }
+}

--- a/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/order/OrderItem.java
+++ b/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/order/OrderItem.java
@@ -1,0 +1,39 @@
+package com.kdt.kdtjpa.domain.order;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Objects;
+
+@Entity
+@Table(name = "order_item")
+@Getter
+public class OrderItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long id;
+
+    private int price;
+    private int quantity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", referencedColumnName = "id")
+    private Order order;
+
+    @OneToMany(mappedBy = "orderItem", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Item> items;
+
+    public void setOrder(Order order) {
+        if (Objects.nonNull(this.order)) {
+            this.order.getOrderItems().remove(this);
+        }
+        this.order = order;
+        order.getOrderItems().add(this);
+    }
+
+    public void addItem(Item item) {
+        item.setOrderItem(this);
+    }
+}

--- a/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/order/OrderStatus.java
+++ b/kdt-jpa/src/main/java/com/kdt/kdtjpa/domain/order/OrderStatus.java
@@ -1,0 +1,5 @@
+package com.kdt.kdtjpa.domain.order;
+
+public enum OrderStatus {
+    OPENED, CANCELLED
+}


### PR DESCRIPTION

## 📌 과제 설명
Order, order_item, item의 연관관계 매핑을 실습해본다.

## 👩‍💻 요구 사항과 구현 내용 
- 연관관계를 학습하고 알맞게 설정하였습니다.

## ✅ PR 포인트 & 궁금한 점 
cascade의 remove와 orphanRemoval = true의 차이점이 무엇일까요?
[블로그 링크](https://velog.io/@yuseogi0218/JPA-CascadeType.REMOVE-vs-orphanRemoval-true#:~:text=CascadeType.REMOVE%20%EC%98%B5%EC%85%98%EC%9D%80%20%EC%9E%90%EC%8B%9D,%EB%90%98%EC%96%B4%20DB%EC%97%90%EC%84%9C%20%EC%82%AD%EC%A0%9C%EB%90%A9%EB%8B%88%EB%8B%A4.)를 통해서 찾아 보았는데 잘 이해가 가지 않네요.
영한님 강의에서는 연관관계 편의 메서드 (값 세팅하는 메서드)는 둘 중 하나 정해서 생성하라고 하는데, fk가 있는 곳을 정해 세팅하는것이 맞을까요?
